### PR TITLE
Initialization mutex

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -257,6 +257,7 @@ declare module '@isomorphic-git/lightning-fs' {
        * @default null
        */
       db?: FS.IDB
+      logger?: any
     }
     export interface IDB {
       constructor(dbname: string, storename: string): IDB

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module '@isomorphic-git/lightning-fs' {
      * @param name This is used to determine the IndexedDb store name.
      * @param options The "filesystem" configuration.
      */
-    init(name: string, options?: FS.Options): void
+    init(name: string, options?: FS.Options): Promise<void>
 
     /**
      * Make directory

--- a/src/CacheFS.js
+++ b/src/CacheFS.js
@@ -111,6 +111,15 @@ module.exports = class CacheFS {
     let parts = path.split(filepath)
     for (let i = 0; i < parts.length; ++ i) {
       let part = parts[i];
+
+      /**
+       * There may be race conditions where the root gets wiped (likely during reinitializing) before the
+       * `dir.get` call below on line 123. This prevents any potential TypeErrors from being thrown.
+       */
+      if (!dir) {
+        throw new ENOTDIR()
+      }
+
       dir = dir.get(part);
       if (!dir) throw new ENOENT(filepath);
       // Follow symlinks

--- a/src/PromisifiedFS.js
+++ b/src/PromisifiedFS.js
@@ -112,9 +112,15 @@ module.exports = class PromisifiedFS {
         name: fn.name,
         args,
       }
-      this._operations.add(op)
       try {
         await this._activate()
+        /**
+         * If this is before activate, gracefulShutdown can get stuck with
+         * new items in the operations set that are waiting to start, which
+         * can cause a deadlock
+         * Happens when calling init while operations are in progress (werid timing)
+         */
+        this._operations.add(op)
         return await fn.apply(this, args)
       } finally {
         this._operations.delete(op)


### PR DESCRIPTION
Add a mutex to gate keep initialization the same database name multiple times
Fix a cycle that was blocking awaiting the end of initialization (this.stat) as it had a dependency on the inialization promise already being done before it could execute